### PR TITLE
refactor: Use Conda-forge build based ROOT image for base Docker image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish Docker Images
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - v*
+
+jobs:
+  build-and-publish:
+    name: Build and publish Docker images to Docker Hub
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Build and Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@2.12
+      with:
+        name: pyhf/pyhf-validation
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        buildoptions: "--compress"
+        tags: "latest,root6.20.00,root6.20.00-python3.7"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim as base
+FROM pyhf/pyhf-validation-root-base:root6.20.00-python3.7 as base
 
 FROM base as builder
 COPY . /code
@@ -14,5 +14,5 @@ RUN cd /code && \
     python -m pip list
 
 FROM base
-COPY --from=builder /usr/local /usr/local
-ENTRYPOINT ["/usr/local/bin/pyhf-validation"]
+COPY --from=builder /opt/condaenv /opt/condaenv
+ENTRYPOINT ["/opt/condaenv/bin/pyhf-validation"]


### PR DESCRIPTION
Update the Dockerfile to use the [current Conda-forge build based `pyhf/pyhf-validation-root-base` Docker image](https://github.com/pyhf/pyhf-validation-root-base/pull/1) as the base image. This will provide a Docker image that can then be used for testing in the CI as well as be distributed as a uniform testing and validation platform.

```
* Use Conda-forge based ROOT base image
   - c.f. https://github.com/pyhf/pyhf-validation-root-base/pull/1
* Add GitHub Actions CI to publish to Docker Hub
```