### PR TITLE
refactor: Use source build based ROOT image for base Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Validation utilities for HistFactory workspaces
 [![CodeFactor](https://www.codefactor.io/repository/github/pyhf/pyhf-validation/badge)](https://www.codefactor.io/repository/github/pyhf/pyhf-validation)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
+[![Docker Pulls](https://img.shields.io/docker/pulls/pyhf/pyhf-validation)](https://hub.docker.com/r/pyhf/pyhf-validation)
+[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/pyhf/pyhf-validation/latest)](https://hub.docker.com/r/pyhf/pyhf-validation/tags?name=latest)
+
 ## Installation
 
 To install `pyhf-validation` from GitHub (PyPI coming soon) run

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,5 +14,5 @@ RUN cd /code && \
     python -m pip list
 
 FROM base
-COPY --from=builder /opt/condaenv /opt/condaenv
-ENTRYPOINT ["/opt/condaenv/bin/pyhf-validation"]
+COPY --from=builder /usr/local /usr/local
+ENTRYPOINT ["/usr/local/bin/pyhf-validation"]


### PR DESCRIPTION
Update the Dockerfile to use the [current ROOT source build based `pyhf/pyhf-validation-root-base` Docker image](https://github.com/pyhf/pyhf-validation-root-base/pull/7) as the base image. This will provide a Docker image that can then be used for testing in the CI as well as be distributed as a uniform testing and validation platform.

```
* Use ROOT source based ROOT base image
   - c.f. https://github.com/pyhf/pyhf-validation-root-base/pull/7
   - Amends PR #8
* Add Docker Hub badges to README