### PR TITLE
ci: Use official Docker GitHub Action for publication to Docker Hub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,10 +2,10 @@ name: Publish Docker Images
 
 on:
   push:
-    # branches:
-    # - master
-    # tags:
-    # - v*
+    branches:
+    - master
+    tags:
+    - v*
 
 jobs:
   build-and-publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build and Publish to Registry
-      if: ! ${{ startsWith(github.ref, 'refs/tags/') }}
+      if: "! ${{ startsWith(github.ref, 'refs/tags/') }}"
       uses: docker/build-push-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,6 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build and Publish to Registry
-      if: ${{ startsWith(github.ref, 'refs/tags/') }} == false
       uses: docker/build-push-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
@@ -23,8 +22,8 @@ jobs:
         repository: pyhf/pyhf-validation
         dockerfile: docker/Dockerfile
         tags: latest,root6.20.00,root6.20.00-python3.7
+        tag_with_ref: ${{ startsWith(github.ref, 'refs/tags/') }}
     - name: Build and Publish to Registry with tag
-      if: ${{ startsWith(github.ref, 'refs/tags/') }} == true
       uses: docker/build-push-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
@@ -32,4 +31,5 @@ jobs:
         repository: pyhf/pyhf-validation
         dockerfile: docker/Dockerfile
         tags: latest,latest-stable,root6.20.00,root6.20.00-python3.7
-        tag_with_ref: true
+        tag_with_ref: true 
+        push: ${{ startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
         tags: latest,root6.20.00,root6.20.00-python3.7
         tag_with_ref: ${{ startsWith(github.ref, 'refs/tags/') }}
     - name: Build and Publish to Registry with tag
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
       uses: docker/build-push-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
@@ -31,5 +32,5 @@ jobs:
         repository: pyhf/pyhf-validation
         dockerfile: docker/Dockerfile
         tags: latest,latest-stable,root6.20.00,root6.20.00-python3.7
-        tag_with_ref: true 
+        tag_with_ref: true
         push: ${{ startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build and Publish to Registry
+      if: ! ${{ startsWith(github.ref, 'refs/tags/') }}
       uses: docker/build-push-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
@@ -22,8 +23,7 @@ jobs:
         repository: pyhf/pyhf-validation
         dockerfile: docker/Dockerfile
         tags: latest,root6.20.00,root6.20.00-python3.7
-        tag_with_ref: ${{ startsWith(github.ref, 'refs/tags/') }}
-    - name: Build and Publish to Registry with tag
+    - name: Build and Publish to Registry with Release Tag
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
       uses: docker/build-push-action@v1
       with:
@@ -33,4 +33,3 @@ jobs:
         dockerfile: docker/Dockerfile
         tags: latest,latest-stable,root6.20.00,root6.20.00-python3.7
         tag_with_ref: true
-        push: ${{ startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,10 +2,10 @@ name: Publish Docker Images
 
 on:
   push:
-    branches:
-    - master
-    tags:
-    - v*
+    # branches:
+    # - master
+    # tags:
+    # - v*
 
 jobs:
   build-and-publish:
@@ -15,11 +15,21 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build and Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@2.12
+      if: ${{ startsWith(github.ref, 'refs/tags/') }} == false
+      uses: docker/build-push-action@v1
       with:
-        name: pyhf/pyhf-validation
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: pyhf/pyhf-validation
         dockerfile: docker/Dockerfile
-        buildoptions: "--compress"
-        tags: "latest,root6.20.00,root6.20.00-python3.7"
+        tags: latest,root6.20.00,root6.20.00-python3.7
+    - name: Build and Publish to Registry with tag
+      if: ${{ startsWith(github.ref, 'refs/tags/') }} == true
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: pyhf/pyhf-validation
+        dockerfile: docker/Dockerfile
+        tags: latest,latest-stable,root6.20.00,root6.20.00-python3.7
+        tag_with_ref: true


### PR DESCRIPTION
Use the [official Docker GitHub Action](https://github.com/docker/build-push-action) (released today) to publish to the Docker image to Docker Hub.

Using the `tag_with_ref` option, tag the image with the version release number and `latest-stable` when the push is a tag release.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use official Docker GitHub Action to publish to Docker Hub
   - Tag image with version release and 'latest-stable' tags if the push is a tag release
```