### PR TITLE
style: Update to Black v20.8 formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: stable
+    rev: 20.8b1
     hooks:
     - id: black
-      language_version: python3.7
+      language_version: python3

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras_require = {
         "black",
         "twine",
     ],
-    "test": ["matplotlib",],
+    "test": ["matplotlib"],
 }
 extras_require["complete"] = sorted(set(sum(extras_require.values(), [])))
 


### PR DESCRIPTION
```
* Apply Black v20.8b1 formatting
   - Should be similar to format of first stable release of Black
* Update Black pre-commit hook to use rev v20.8b1
   - Using pinned revs is the recommended approach for pre-commit: https://github.com/psf/black/issues/420
```