### PR TITLE
fix: Avoid first time startup costs in tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,8 @@ import time
 
 def test_version(script_runner):
     command = "pyhf-validation --version"
+    # Run once to ensure first time setup doesn't slow down 
+    script_runner.run(*shlex.split(command))
     start = time.time()
     ret = script_runner.run(*shlex.split(command))
     end = time.time()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ import time
 
 def test_version(script_runner):
     command = "pyhf-validation --version"
-    # Run once to ensure first time setup doesn't slow down 
+    # Run once to ensure first time setup doesn't slow down
     script_runner.run(*shlex.split(command))
     start = time.time()
     ret = script_runner.run(*shlex.split(command))


### PR DESCRIPTION
Resolves #14 

To avoid startup costs that are associated with the first time the tests are run, run the command once first to make sure everything is setup in the environment

```
* Run pyhf-validation --version once before test to avoid first run post install startup costs
```