### PR TITLE
ci: Drop testing of Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.7', '3.8', '3.9']
-      include:
-        - os: macos-latest
-          python-version: '3.7'
-        - os: macos-latest
-          python-version: '3.9'
+        include:
+          - os: macos-latest
+            python-version: '3.7'
+          - os: macos-latest
+            python-version: '3.9'
 
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
`macos-latest` supports Python 3.7+ and pyhf supports Python 3.7+

```
* Drop testing of Python 3.6 in CI and test ends of support for macOS
(which are Python 3.7 and Python 3.9)
   - Modern pyhf is Python 3.7+
   - GitHub Actions macos-latest VMs support Python 3.7+ as of October 2021
```