### PR TITLE
build: Drop Python 3.6 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as readme_md
 extras_require = {
     "develop": [
         "check-manifest",
-        "pytest~=5.2",
+        "pytest~=6.0",
         "pytest-cov~=2.8",
         "pytest-console-scripts~=0.2",
         "bumpversion~=0.5",
@@ -36,6 +36,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     package_dir={"": "src"},
     packages=find_packages(where="src"),


### PR DESCRIPTION
Drop Python 3.6 support as modern pyhf is Python 3.7+

```
* Require Python 3.7+ as is require by pyhf v0.6.0+
* Require pyhf v0.6.0+
* Remove CPython 3.6 and add CPython 3.9 support to PyPI metadata
* Use pytest versions compatible with v6.X
```