### PR TITLE
ci: Use stable versions for reporting coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
 
     - name: Report coverage with Codecov
       if: github.event_name == 'push' && matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
-      uses: codecov/codecov-action@master
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         pytest -r sx tests
 
     - name: Report coverage with Codecov
-      if: github.event_name == 'push' && matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
+      if: github.event_name == 'push' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
-        flags: unittests
+        flags: unittests-${{ matrix.python-version }}
 
   docker:
 


### PR DESCRIPTION
```
* Use a stable tag of codecov/codecov-action for reporting coverage.
* Report coverage for all Python versions tested.
```