### PR TITLE
docs: Use 'req@url' syntax to install from remote VCS

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Validation utilities for HistFactory workspaces
 
 To install `pyhf-validation` from GitHub (PyPI coming soon) run
 ```bash
-python -m pip install "git+https://github.com/pyhf/pyhf-validation.git#egg=hfval"
+python -m pip install "hfval@git+https://github.com/pyhf/pyhf-validation.git"
 ```
 
 ## Developing


### PR DESCRIPTION
* Use 'req@url' syntax when using pip to install from a remote git repository over 'url#egg=req' to avoid the use of #egg= fragments with a non-PEP 508 name. This will be required in pip v25.0+.
   - c.f. pypa/pip#11617 for more details.